### PR TITLE
Improve JWT Exception Handler; Rescue From Decode Error Super Class

### DIFF
--- a/app/lib/json_web_token.rb
+++ b/app/lib/json_web_token.rb
@@ -14,7 +14,7 @@ class JsonWebToken
     body = JWT.decode(token, HMAC_SECRET)[0]
     HashWithIndifferentAccess.new body
     # rescue from expiry exception
-  rescue JWT::ExpiredSignature, JWT::VerificationError => e
+  rescue JWT::DecodeError => e
     # raise custom error to be handled by custom handler
     raise ExceptionHandler::InvalidToken, e.message
   end

--- a/spec/auth/authorize_api_request_spec.rb
+++ b/spec/auth/authorize_api_request_spec.rb
@@ -54,6 +54,19 @@ RSpec.describe AuthorizeApiRequest do
             )
         end
       end
+
+      context 'fake token' do
+        let(:header) { { 'Authorization' => 'foobar' } }
+        subject(:invalid_request_obj) { described_class.new(header) }
+
+        it 'handles JWT::DecodeError' do
+          expect { invalid_request_obj.call }
+            .to raise_error(
+              ExceptionHandler::InvalidToken,
+              /Not enough or too many segments/
+            )
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
### What does this PR do

Improves the `jwt` singleton to rescue from all `jwt` decode exceptions aka `JWT::DecodeError`.
  
  Closes #5 
  